### PR TITLE
Handle missing firmware subversion segments

### DIFF
--- a/Elatec.NET.cs
+++ b/Elatec.NET.cs
@@ -120,17 +120,7 @@ namespace Elatec.NET
             var parser = await CallFunctionAsync(new byte[] { API_SYS, 4, /* maxLen */ byte.MaxValue });
             string version = parser.ParseAsciiString();
             var subVersion = version.Split('/');
-            if (subVersion.Length > 0)
-            {
-                if (subVersion[2].Contains('B'))
-                {
-                    IsTWN4LegicReader = true;
-                }
-                else
-                {
-                    IsTWN4LegicReader = false;
-                }
-            }
+            IsTWN4LegicReader = subVersion.Length >= 3 && subVersion[2].Contains('B');
             return version;
         }
 


### PR DESCRIPTION
## Summary
- add a length check before inspecting firmware subversion segment
- default IsTWN4LegicReader to false when version format is unexpected

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a054b8594833181a9d898d4c07d4a)