### PR TITLE
Fix DisconnectAsync return semantics

### DIFF
--- a/Elatec.NET.cs
+++ b/Elatec.NET.cs
@@ -2102,21 +2102,24 @@ namespace Elatec.NET
         /// <returns></returns>
         public async Task<bool> DisconnectAsync()
         {
-            await Task.Run(() =>
+            var wasDisconnected = await Task.Run(() =>
             {
                 try
                 {
                     if (twnPort == null)
                     {
-                        return;
+                        return true;
                     }
 
-                    else if(twnPort.IsOpen)
+                    if (twnPort.IsOpen)
                     {
                         twnPort.DiscardInBuffer();
                         twnPort.DiscardOutBuffer();
                         twnPort.Close();
+                        return true;
                     }
+
+                    return true;
                 }
                 catch (Exception e)
                 {
@@ -2130,10 +2133,12 @@ namespace Elatec.NET
                     {
                         throw new ReaderException("Call was not successfull, error " + Enum.GetName(typeof(ReaderError), ReaderError.NotInit), null);
                     }
+
+                    throw;
                 }
             }).ConfigureAwait(false);
 
-            return false;
+            return wasDisconnected;
         }
 
         #region Tools for Simple Protocol


### PR DESCRIPTION
## Summary
- adjust DisconnectAsync to return success when the port is closed or absent while keeping error propagation
- ensure unexpected exceptions are not swallowed during disconnect

## Testing
- dotnet test (fails: dotnet not installed in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a06bcf48c83319c7446276240b8f6)