### PR TITLE
Dispose serial port handle on dispose

### DIFF
--- a/Elatec.NET.cs
+++ b/Elatec.NET.cs
@@ -2342,9 +2342,18 @@ namespace Elatec.NET
             if (!_disposed)
             {
                 if (disposing)
-                {                 
+                {
                     // Dispose any managed objects
-                    // ...
+                    if (twnPort != null)
+                    {
+                        if (twnPort.IsOpen)
+                        {
+                            twnPort.Close();
+                        }
+
+                        twnPort.Dispose();
+                        twnPort = null;
+                    }
                 }
 
                 Thread.Sleep(20);


### PR DESCRIPTION
## Summary
- close and dispose the serial port when disposing managed resources
- reset the serial port field to prevent reuse after disposal

## Testing
- dotnet build *(fails: `dotnet` command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a079eccd0833187649d2a0d1f0925)