### PR TITLE
Organize reader transport interface namespace

### DIFF
--- a/Elatec.NET.Tests/Elatec.NET.Tests.csproj
+++ b/Elatec.NET.Tests/Elatec.NET.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Elatec.NET.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1" />
+  </ItemGroup>
+</Project>

--- a/Elatec.NET.Tests/TWN4ReaderDeviceTests.cs
+++ b/Elatec.NET.Tests/TWN4ReaderDeviceTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+using Elatec.NET.Interfaces;
+
+namespace Elatec.NET.Tests
+{
+    public class TWN4ReaderDeviceTests
+    {
+        [Fact]
+        public async Task CallFunctionRawAsync_UsesTransportToSendAndReceive()
+        {
+            var fakeTransport = new FakeReaderTransport("COM1");
+            fakeTransport.Responses.Enqueue("0001");
+            var device = new TWN4ReaderDevice("COM1", _ => fakeTransport);
+
+            var response = await device.CallFunctionRawAsync(new byte[] { 0xAA });
+
+            Assert.True(fakeTransport.ConnectCalled);
+            Assert.Single(fakeTransport.WrittenLines, "AA");
+            Assert.Equal(new byte[] { 0x00, 0x01 }, response);
+        }
+
+        [Fact]
+        public async Task DisconnectAsync_InvokesTransportClose()
+        {
+            var fakeTransport = new FakeReaderTransport("COM2");
+            fakeTransport.Responses.Enqueue("00");
+            var device = new TWN4ReaderDevice("COM2", _ => fakeTransport);
+
+            await device.CallFunctionRawAsync(new byte[] { 0x00 });
+            var result = await device.DisconnectAsync();
+
+            Assert.True(result);
+            Assert.False(fakeTransport.IsOpen);
+        }
+    }
+
+    /// <summary>
+    /// Minimal fake transport used to validate transport interactions without hardware.
+    /// </summary>
+    public class FakeReaderTransport : IReaderTransport
+    {
+        public FakeReaderTransport(string portName)
+        {
+            PortName = portName;
+        }
+
+        public string PortName { get; }
+
+        public int ReadTimeout { get; set; }
+
+        public int WriteTimeout { get; set; }
+
+        public bool IsOpen { get; private set; }
+
+        public bool ConnectCalled { get; private set; }
+
+        public Queue<string> Responses { get; } = new Queue<string>();
+
+        public List<string> WrittenLines { get; } = new List<string>();
+
+        public event EventHandler<Exception> ErrorReceived;
+
+        public Task ConnectAsync()
+        {
+            ConnectCalled = true;
+            IsOpen = true;
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync()
+        {
+            IsOpen = false;
+            return Task.CompletedTask;
+        }
+
+        public void DiscardInBuffer()
+        {
+        }
+
+        public void DiscardOutBuffer()
+        {
+        }
+
+        public Task<string> ReadLineAsync()
+        {
+            if (Responses.Count == 0)
+            {
+                throw new InvalidOperationException("No responses configured.");
+            }
+
+            return Task.FromResult(Responses.Dequeue());
+        }
+
+        public Task WriteLineAsync(string data)
+        {
+            WrittenLines.Add(data);
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            IsOpen = false;
+        }
+    }
+}

--- a/Elatec.NET.cs
+++ b/Elatec.NET.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO.Ports;
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Elatec.NET.Cards;
 using Elatec.NET.Cards.Mifare;
+using Elatec.NET.Interfaces;
 using Elatec.NET.Helpers.ByteArrayHelper.Extensions;
 using System.IO;
 
@@ -41,7 +41,8 @@ namespace Elatec.NET
 
         private static readonly object syncRoot = new object();
         private static List<TWN4ReaderDevice> instance;
-        private SerialPort twnPort;
+        private readonly Func<string, IReaderTransport> _transportFactory;
+        private IReaderTransport _transport;
 
         public static List<TWN4ReaderDevice> Instance
         {
@@ -64,15 +65,25 @@ namespace Elatec.NET
         /// <summary>
         /// 
         /// </summary>
-        public TWN4ReaderDevice(string portName)
+        public TWN4ReaderDevice(string portName, Func<string, IReaderTransport> transportFactory = null)
         {
             PortName = portName;
+            _transportFactory = transportFactory ?? (name => new SerialPortTransport(name));
         }
 
         /// <summary>
         /// 
         /// </summary>
         public static readonly int TIMEOUT = 20;
+
+        private void EnsureTransport()
+        {
+            if (_transport == null)
+            {
+                _transport = _transportFactory(PortName) ?? throw new InvalidOperationException("Transport factory returned null.");
+                _transport.ErrorReceived += TXRXErr;
+            }
+        }
 
         #region High Level APIs
 
@@ -578,50 +589,37 @@ namespace Elatec.NET
         /// <returns></returns>
         public async Task<bool> ConnectAsync()
         {
-            await Task.Run(() =>
+            try
             {
-                try
+                EnsureTransport();
+
+                // NFC functions are known to take less than 2 second to execute.
+                _transport.ReadTimeout = 2000;
+                _transport.WriteTimeout = 2000;
+
+                // Open TWN4 com port
+                await _transport.ConnectAsync().ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                //Port Busy? Try Again
+                if (e is UnauthorizedAccessException)
                 {
-                    if (twnPort == null)
+                    if (_transport != null && _transport.IsOpen)
                     {
-                        twnPort = new SerialPort();
+                        await _transport.DisconnectAsync().ConfigureAwait(false);
                     }
 
-                    // Initialize serial port
-                    twnPort.PortName = PortName;
-                    twnPort.BaudRate = 9600;
-                    twnPort.DataBits = 8;
-                    twnPort.StopBits = System.IO.Ports.StopBits.One;
-                    twnPort.Parity = System.IO.Ports.Parity.None;
-                    // NFC functions are known to take less than 2 second to execute.
-                    twnPort.ReadTimeout = 2000;
-                    twnPort.WriteTimeout = 2000;
-                    twnPort.NewLine = "\r";
-                    twnPort.ErrorReceived += TXRXErr;
-                    // Open TWN4 com port
-                    twnPort.Open();
+                    throw new ReaderException("Call was not successfull, error " + Enum.GetName(typeof(ReaderError), ReaderError.NotOpen), null);
                 }
-                catch (Exception e)
+
+                if (e is IOException)
                 {
-                    //Port Busy? Try Again
-                    if (e is UnauthorizedAccessException)
-                    {
-                        if (twnPort.IsOpen)
-                        {
-                            twnPort.Close();
-                        }
-
-                        throw new ReaderException("Call was not successfull, error " + Enum.GetName(typeof(ReaderError), ReaderError.NotOpen), null);
-                    }
-
-                    if (e is IOException)
-                    {
-                        instance = DeviceManager.GetAvailableReaders();
-                    }
-
-                    throw new ReaderException("Call was not successfull, error " + Enum.GetName(typeof(ReaderError), ReaderError.NotInit), null);
+                    instance = DeviceManager.GetAvailableReaders();
                 }
-            }).ConfigureAwait(false);
+
+                throw new ReaderException("Call was not successfull, error " + Enum.GetName(typeof(ReaderError), ReaderError.NotInit), null);
+            }
 
             var version = await GetVersionStringAsync();
             return version.StartsWith("TWN4");
@@ -633,43 +631,38 @@ namespace Elatec.NET
         /// <returns></returns>
         public async Task<bool> DisconnectAsync()
         {
-            var wasDisconnected = await Task.Run(() =>
+            try
             {
-                try
+                if (_transport == null)
                 {
-                    if (twnPort == null)
-                    {
-                        return true;
-                    }
-
-                    if (twnPort.IsOpen)
-                    {
-                        twnPort.DiscardInBuffer();
-                        twnPort.DiscardOutBuffer();
-                        twnPort.Close();
-                        return true;
-                    }
-
                     return true;
                 }
-                catch (Exception e)
+
+                if (_transport.IsOpen)
                 {
-                    //Port Busy? Try Again
-                    if (e is UnauthorizedAccessException)
-                    {
-                        throw new ReaderException("Call was not successfull, error " + Enum.GetName(typeof(ReaderError), ReaderError.NotOpen), null);
-                    }
-
-                    if (e is IOException)
-                    {
-                        throw new ReaderException("Call was not successfull, error " + Enum.GetName(typeof(ReaderError), ReaderError.NotInit), null);
-                    }
-
-                    throw;
+                    _transport.DiscardInBuffer();
+                    _transport.DiscardOutBuffer();
+                    await _transport.DisconnectAsync().ConfigureAwait(false);
+                    return true;
                 }
-            }).ConfigureAwait(false);
 
-            return wasDisconnected;
+                return true;
+            }
+            catch (Exception e)
+            {
+                //Port Busy? Try Again
+                if (e is UnauthorizedAccessException)
+                {
+                    throw new ReaderException("Call was not successfull, error " + Enum.GetName(typeof(ReaderError), ReaderError.NotOpen), null);
+                }
+
+                if (e is IOException)
+                {
+                    throw new ReaderException("Call was not successfull, error " + Enum.GetName(typeof(ReaderError), ReaderError.NotInit), null);
+                }
+
+                throw;
+            }
         }
 
         #region Tools for Simple Protocol
@@ -789,32 +782,23 @@ namespace Elatec.NET
         {
             try
             {
-                byte[] ret = null;
+                EnsureTransport();
 
-                return await Task.Run(() => 
+                if (!_transport.IsOpen)
                 {
-                    if (!twnPort.IsOpen)
-                    {
-                        twnPort.Open();
-                    }
+                    await _transport.ConnectAsync().ConfigureAwait(false);
+                }
 
-                    else if (twnPort.IsOpen)
-                    {
-                        // Discard com port inbuffer
-                        twnPort.DiscardInBuffer();
+                // Discard com port inbuffer
+                _transport.DiscardInBuffer();
 
-                        // Generate simple protocol string and send command
-                        twnPort.WriteLine(GetPRSfromByteArray(CMD));
+                // Generate simple protocol string and send command
+                await _transport.WriteLineAsync(GetPRSfromByteArray(CMD)).ConfigureAwait(false);
 
-                        // Read simple protocoll string and convert to byte array
-                        ret = GetByteArrayfromPRS(twnPort.ReadLine());
+                // Read simple protocoll string and convert to byte array
+                var rawResponse = await _transport.ReadLineAsync().ConfigureAwait(false);
+                return GetByteArrayfromPRS(rawResponse);
 
-                        return ret;
-                    }
-
-                    return ret;
-
-                }).ConfigureAwait(false);
             }
 
             catch
@@ -829,7 +813,7 @@ namespace Elatec.NET
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void TXRXErr(object sender, EventArgs e)
+        private void TXRXErr(object sender, Exception e)
         {
             throw new ReaderException("Call was not successfull, error " + e.ToString(), null);
         }
@@ -847,12 +831,7 @@ namespace Elatec.NET
         {
             get
             {
-                if (twnPort != null)
-                {
-                    return twnPort.IsOpen;
-                }
-
-                return false;
+                return _transport != null && _transport.IsOpen;
             }
         }
 
@@ -875,15 +854,15 @@ namespace Elatec.NET
                 if (disposing)
                 {
                     // Dispose any managed objects
-                    if (twnPort != null)
+                    if (_transport != null)
                     {
-                        if (twnPort.IsOpen)
+                        if (_transport.IsOpen)
                         {
-                            twnPort.Close();
+                            _transport.DisconnectAsync().GetAwaiter().GetResult();
                         }
 
-                        twnPort.Dispose();
-                        twnPort = null;
+                        _transport.Dispose();
+                        _transport = null;
                     }
                 }
 

--- a/Elatec.NET.sln
+++ b/Elatec.NET.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.7.34221.43
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elatec.NET", "Elatec.NET.csproj", "{53FBD2F3-638E-4892-9F09-9A372C8F76D2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elatec.NET.Tests", "Elatec.NET.Tests\\Elatec.NET.Tests.csproj", "{1767A7E5-6C9A-46AC-A6FD-B07080AC0CE3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -25,9 +27,21 @@ Global
 		{53FBD2F3-638E-4892-9F09-9A372C8F76D2}.Release|Any CPU.Build.0 = Release|Any CPU
 		{53FBD2F3-638E-4892-9F09-9A372C8F76D2}.Release|x64.ActiveCfg = Release|x64
 		{53FBD2F3-638E-4892-9F09-9A372C8F76D2}.Release|x64.Build.0 = Release|x64
-		{53FBD2F3-638E-4892-9F09-9A372C8F76D2}.Release|x86.ActiveCfg = Release|x86
-		{53FBD2F3-638E-4892-9F09-9A372C8F76D2}.Release|x86.Build.0 = Release|x86
-	EndGlobalSection
+                {53FBD2F3-638E-4892-9F09-9A372C8F76D2}.Release|x86.ActiveCfg = Release|x86
+                {53FBD2F3-638E-4892-9F09-9A372C8F76D2}.Release|x86.Build.0 = Release|x86
+                {1767A7E5-6C9A-46AC-A6FD-B07080AC0CE3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {1767A7E5-6C9A-46AC-A6FD-B07080AC0CE3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {1767A7E5-6C9A-46AC-A6FD-B07080AC0CE3}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {1767A7E5-6C9A-46AC-A6FD-B07080AC0CE3}.Debug|x64.Build.0 = Debug|Any CPU
+                {1767A7E5-6C9A-46AC-A6FD-B07080AC0CE3}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {1767A7E5-6C9A-46AC-A6FD-B07080AC0CE3}.Debug|x86.Build.0 = Debug|Any CPU
+                {1767A7E5-6C9A-46AC-A6FD-B07080AC0CE3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {1767A7E5-6C9A-46AC-A6FD-B07080AC0CE3}.Release|Any CPU.Build.0 = Release|Any CPU
+                {1767A7E5-6C9A-46AC-A6FD-B07080AC0CE3}.Release|x64.ActiveCfg = Release|Any CPU
+                {1767A7E5-6C9A-46AC-A6FD-B07080AC0CE3}.Release|x64.Build.0 = Release|Any CPU
+                {1767A7E5-6C9A-46AC-A6FD-B07080AC0CE3}.Release|x86.ActiveCfg = Release|Any CPU
+                {1767A7E5-6C9A-46AC-A6FD-B07080AC0CE3}.Release|x86.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/Interfaces/IReaderTransport.cs
+++ b/Interfaces/IReaderTransport.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Elatec.NET.Interfaces
+{
+    /// <summary>
+    /// Provides a transport abstraction for communicating with TWN reader hardware.
+    /// Implementations are responsible for connecting, reading, writing and managing timeouts.
+    /// </summary>
+    public interface IReaderTransport : IDisposable
+    {
+        /// <summary>
+        /// Gets the name of the underlying port or connection.
+        /// </summary>
+        string PortName { get; }
+
+        /// <summary>
+        /// Gets or sets the read timeout in milliseconds.
+        /// </summary>
+        int ReadTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the write timeout in milliseconds.
+        /// </summary>
+        int WriteTimeout { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the transport is connected.
+        /// </summary>
+        bool IsOpen { get; }
+
+        /// <summary>
+        /// Connect to the reader transport.
+        /// </summary>
+        Task ConnectAsync();
+
+        /// <summary>
+        /// Disconnect from the reader transport.
+        /// </summary>
+        Task DisconnectAsync();
+
+        /// <summary>
+        /// Read a line of data from the transport.
+        /// </summary>
+        Task<string> ReadLineAsync();
+
+        /// <summary>
+        /// Write a line of data to the transport.
+        /// </summary>
+        Task WriteLineAsync(string data);
+
+        /// <summary>
+        /// Discard any buffered incoming data.
+        /// </summary>
+        void DiscardInBuffer();
+
+        /// <summary>
+        /// Discard any buffered outgoing data.
+        /// </summary>
+        void DiscardOutBuffer();
+
+        /// <summary>
+        /// Raised when the transport encounters a communication error.
+        /// </summary>
+        event EventHandler<Exception> ErrorReceived;
+    }
+}

--- a/System/SerialPortTransport.cs
+++ b/System/SerialPortTransport.cs
@@ -1,0 +1,131 @@
+using System;
+using System.IO;
+using System.IO.Ports;
+using System.Threading.Tasks;
+using Elatec.NET.Interfaces;
+
+namespace Elatec.NET
+{
+    /// <summary>
+    /// Serial port based implementation of <see cref="IReaderTransport"/>.
+    /// </summary>
+    public class SerialPortTransport : IReaderTransport
+    {
+        private readonly SerialPort _serialPort;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SerialPortTransport"/> class for the given port.
+        /// </summary>
+        /// <param name="portName">Name of the serial port used to reach the reader.</param>
+        public SerialPortTransport(string portName)
+        {
+            if (string.IsNullOrWhiteSpace(portName))
+            {
+                throw new ArgumentException("Port name must be provided.", nameof(portName));
+            }
+
+            _serialPort = new SerialPort
+            {
+                PortName = portName,
+                BaudRate = 9600,
+                DataBits = 8,
+                StopBits = StopBits.One,
+                Parity = Parity.None,
+                NewLine = "\r"
+            };
+
+            _serialPort.ErrorReceived += OnErrorReceived;
+        }
+
+        /// <inheritdoc />
+        public string PortName => _serialPort.PortName;
+
+        /// <inheritdoc />
+        public int ReadTimeout
+        {
+            get => _serialPort.ReadTimeout;
+            set => _serialPort.ReadTimeout = value;
+        }
+
+        /// <inheritdoc />
+        public int WriteTimeout
+        {
+            get => _serialPort.WriteTimeout;
+            set => _serialPort.WriteTimeout = value;
+        }
+
+        /// <inheritdoc />
+        public bool IsOpen => _serialPort.IsOpen;
+
+        /// <inheritdoc />
+        public event EventHandler<Exception> ErrorReceived;
+
+        /// <inheritdoc />
+        public async Task ConnectAsync()
+        {
+            await Task.Run(() =>
+            {
+                if (!_serialPort.IsOpen)
+                {
+                    _serialPort.Open();
+                }
+            }).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task DisconnectAsync()
+        {
+            await Task.Run(() =>
+            {
+                if (_serialPort.IsOpen)
+                {
+                    _serialPort.DiscardInBuffer();
+                    _serialPort.DiscardOutBuffer();
+                    _serialPort.Close();
+                }
+            }).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public void DiscardInBuffer()
+        {
+            _serialPort.DiscardInBuffer();
+        }
+
+        /// <inheritdoc />
+        public void DiscardOutBuffer()
+        {
+            _serialPort.DiscardOutBuffer();
+        }
+
+        /// <inheritdoc />
+        public async Task<string> ReadLineAsync()
+        {
+            return await Task.Run(() => _serialPort.ReadLine()).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task WriteLineAsync(string data)
+        {
+            await Task.Run(() => _serialPort.WriteLine(data)).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            _serialPort.ErrorReceived -= OnErrorReceived;
+
+            if (_serialPort.IsOpen)
+            {
+                _serialPort.Close();
+            }
+
+            _serialPort.Dispose();
+        }
+
+        private void OnErrorReceived(object sender, SerialErrorReceivedEventArgs e)
+        {
+            ErrorReceived?.Invoke(this, new IOException($"Serial port error: {e.EventType}"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move `IReaderTransport` into an Interfaces namespace/directory for clearer structure
- update transport implementation and device/tests to consume the new namespace

## Testing
- `dotnet test` *(fails: `dotnet` command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694070bdd3ec833193a35efdbb2a1bd6)