### PR TITLE
Abstract device enumeration and add tests

### DIFF
--- a/Elatec.NET.Tests/WindowsDeviceEnumeratorTests.cs
+++ b/Elatec.NET.Tests/WindowsDeviceEnumeratorTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Elatec.NET.Tests
+{
+    public class WindowsDeviceEnumeratorTests
+    {
+        [Fact]
+        public void FindUsbDevices_ValidatesArguments()
+        {
+            var enumerator = new WindowsDeviceEnumerator();
+
+            Assert.Throws<ArgumentException>(() => enumerator.FindUsbDevices(null, "vid", "pid"));
+            Assert.Throws<ArgumentException>(() => enumerator.FindUsbDevices("svc", null, "pid"));
+            Assert.Throws<ArgumentException>(() => enumerator.FindUsbDevices("svc", "vid", null));
+        }
+
+        [Fact]
+        public void FilterDevices_ReturnsOnlyMatchingUsbDevices()
+        {
+            var values = new object[]
+            {
+                "USB\\VID_09D8&PID_0420\\7&123456&0&3",
+                "USB\\VID_09D8&PID_0420\\7&9999&0&4",
+                "USB\\VID_0000&PID_0000\\1&1&0&1",
+                42,
+                null
+            };
+
+            var matches = WindowsDeviceEnumerator.FilterDevices(values, "USB\\VID_09D8&PID_0420\\").ToList();
+
+            Assert.Equal(2, matches.Count);
+            Assert.All(matches, match => Assert.StartsWith("USB\\VID_09D8&PID_0420\\", match));
+        }
+
+        [Fact]
+        public void FilterDevices_IgnoresNullCollections()
+        {
+            var matches = WindowsDeviceEnumerator.FilterDevices(null, "USB\\VID_09D8&PID_0420\\").ToList();
+
+            Assert.Empty(matches);
+        }
+    }
+}

--- a/Helpers/DeviceManager.cs
+++ b/Helpers/DeviceManager.cs
@@ -1,85 +1,46 @@
-﻿using Microsoft.Win32;
+using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Elatec.NET.Interfaces;
 
 namespace Elatec.NET
 {
     public class DeviceManager
     {
+        private static IDeviceEnumerator _deviceEnumerator = CreatePlatformEnumerator();
 
-        public static readonly string VendorIdElatec = "09D8";
-        public static readonly string ProductIdTWN4MultiTech2 = "0420";
-        public static readonly string ServiceUsbSerial = "usbser";
+        /// <summary>
+        /// Gets or sets the platform specific device enumerator. Primarily intended for testing.
+        /// </summary>
+        public static IDeviceEnumerator DeviceEnumerator
+        {
+            get => _deviceEnumerator;
+            set => _deviceEnumerator = value ?? throw new ArgumentNullException(nameof(value));
+        }
 
         public static List<TWN4ReaderDevice> GetAvailableReaders()
         {
-            try
-            {
-                var readers = new List<TWN4ReaderDevice>();
-
-                foreach (string deviceInstanceId in FindUsbDevices(ServiceUsbSerial, VendorIdElatec, ProductIdTWN4MultiTech2) ?? new List<string> { "" })
-                {
-                    var portName = RegQuerySZ($"SYSTEM\\CurrentControlSet\\Enum\\{deviceInstanceId}\\Device Parameters", "PortName");
-                    var reader = new TWN4ReaderDevice(portName);
-                    readers.Add(reader);
-                }
-
-                return readers;
-            }
-            catch 
-            {
-                return null;
-            }
-
+            return DeviceEnumerator.GetAvailableReaders() ?? new List<TWN4ReaderDevice>();
         }
 
-        /// <summary>
-        /// Find USB devices of a specified kind.
-        /// </summary>
-        /// <param name="service">e.g. "usbser"</param>
-        /// <param name="vendorId"></param>
-        /// <param name="productId"></param>
-        /// <returns>A list of deviceInstanceIds.</returns>
-        public static List<string> FindUsbDevices(string service, string vendorId, string productId)
+        private static IDeviceEnumerator CreatePlatformEnumerator()
         {
-            RegistryKey registryKey = null;
-            var devices = new List<string>();
-            string devicePath = $"USB\\VID_{vendorId}&PID_{productId}\\";
-
-            try
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                registryKey = Registry.LocalMachine.OpenSubKey($"SYSTEM\\CurrentControlSet\\Services\\{service}\\Enum");
-                if (registryKey == null)
-                {
-                    return null;
-                }
-                string[] valueNames = registryKey.GetValueNames();
-                for (int i = 0; i < valueNames.Length; i++)
-                {
-                    object value = registryKey.GetValue(valueNames[i]);
-                    if (value is string device && device.StartsWith(devicePath))
-                    {
-                        devices.Add(device);
-                    }
-                }
+                return new WindowsDeviceEnumerator();
             }
-            finally
-            {
-                registryKey?.Close();
 
-            }
-            return devices;
-        }
-
-        private static string RegQuerySZ(string subKeyName, string valueName)
-        {
-            RegistryKey registryKey = Registry.LocalMachine.OpenSubKey(subKeyName);
-            if (registryKey == null)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                return null;
+                return new MacOsDeviceEnumerator();
             }
-            object value = registryKey.GetValue(valueName);
-            registryKey.Close();
-            return value?.ToString();
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return new LinuxDeviceEnumerator();
+            }
+
+            return new NullDeviceEnumerator();
         }
     }
 }

--- a/Helpers/LinuxDeviceEnumerator.cs
+++ b/Helpers/LinuxDeviceEnumerator.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using Elatec.NET.Interfaces;
+
+namespace Elatec.NET
+{
+    /// <summary>
+    /// Placeholder for future Linux support using udev or serial port scanning.
+    /// </summary>
+    public class LinuxDeviceEnumerator : IDeviceEnumerator
+    {
+        public List<TWN4ReaderDevice> GetAvailableReaders()
+        {
+            Trace.TraceInformation("Linux device enumeration is not implemented yet. Returning an empty list.");
+            return new List<TWN4ReaderDevice>();
+        }
+    }
+}

--- a/Helpers/MacOsDeviceEnumerator.cs
+++ b/Helpers/MacOsDeviceEnumerator.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using Elatec.NET.Interfaces;
+
+namespace Elatec.NET
+{
+    /// <summary>
+    /// Placeholder for future macOS support using serial port scanning.
+    /// </summary>
+    public class MacOsDeviceEnumerator : IDeviceEnumerator
+    {
+        public List<TWN4ReaderDevice> GetAvailableReaders()
+        {
+            Trace.TraceInformation("macOS device enumeration is not implemented yet. Returning an empty list.");
+            return new List<TWN4ReaderDevice>();
+        }
+    }
+}

--- a/Helpers/NullDeviceEnumerator.cs
+++ b/Helpers/NullDeviceEnumerator.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using Elatec.NET.Interfaces;
+
+namespace Elatec.NET
+{
+    internal class NullDeviceEnumerator : IDeviceEnumerator
+    {
+        public List<TWN4ReaderDevice> GetAvailableReaders()
+        {
+            return new List<TWN4ReaderDevice>();
+        }
+    }
+}

--- a/Helpers/WindowsDeviceEnumerator.cs
+++ b/Helpers/WindowsDeviceEnumerator.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.Win32;
+using Elatec.NET.Interfaces;
+
+namespace Elatec.NET
+{
+    public class WindowsDeviceEnumerator : IDeviceEnumerator
+    {
+        public static readonly string VendorIdElatec = "09D8";
+        public static readonly string ProductIdTWN4MultiTech2 = "0420";
+        public static readonly string ServiceUsbSerial = "usbser";
+
+        public List<TWN4ReaderDevice> GetAvailableReaders()
+        {
+            var readers = new List<TWN4ReaderDevice>();
+
+            foreach (string deviceInstanceId in FindUsbDevices(ServiceUsbSerial, VendorIdElatec, ProductIdTWN4MultiTech2))
+            {
+                var portName = RegQuerySZ($"SYSTEM\\CurrentControlSet\\Enum\\{deviceInstanceId}\\Device Parameters", "PortName");
+                if (string.IsNullOrWhiteSpace(portName))
+                {
+                    Trace.TraceWarning($"Port name not found for device '{deviceInstanceId}'. Ensure the TWN4 drivers are installed.");
+                    continue;
+                }
+
+                var reader = new TWN4ReaderDevice(portName);
+                readers.Add(reader);
+            }
+
+            return readers;
+        }
+
+        internal List<string> FindUsbDevices(string service, string vendorId, string productId)
+        {
+            if (string.IsNullOrWhiteSpace(service))
+            {
+                throw new ArgumentException("Service must be specified.", nameof(service));
+            }
+
+            if (string.IsNullOrWhiteSpace(vendorId))
+            {
+                throw new ArgumentException("Vendor ID must be specified.", nameof(vendorId));
+            }
+
+            if (string.IsNullOrWhiteSpace(productId))
+            {
+                throw new ArgumentException("Product ID must be specified.", nameof(productId));
+            }
+
+            RegistryKey registryKey = null;
+            var devices = new List<string>();
+            string devicePath = $"USB\\VID_{vendorId}&PID_{productId}\\";
+
+            try
+            {
+                registryKey = Registry.LocalMachine.OpenSubKey($"SYSTEM\\CurrentControlSet\\Services\\{service}\\Enum");
+                if (registryKey == null)
+                {
+                    Trace.TraceWarning($"USB serial driver for '{service}' was not found. Ensure the TWN4 drivers are installed.");
+                    return devices;
+                }
+
+                IEnumerable<object> registryValues = registryKey.GetValueNames().Select(registryKey.GetValue);
+                devices.AddRange(FilterDevices(registryValues, devicePath));
+            }
+            finally
+            {
+                registryKey?.Close();
+
+            }
+
+            return devices;
+        }
+
+        internal static IEnumerable<string> FilterDevices(IEnumerable<object> registryValues, string devicePathPrefix)
+        {
+            if (registryValues == null || string.IsNullOrEmpty(devicePathPrefix))
+            {
+                yield break;
+            }
+
+            foreach (object value in registryValues)
+            {
+                if (value is string device && device.StartsWith(devicePathPrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    yield return device;
+                }
+            }
+        }
+
+        private static string RegQuerySZ(string subKeyName, string valueName)
+        {
+            RegistryKey registryKey = Registry.LocalMachine.OpenSubKey(subKeyName);
+            if (registryKey == null)
+            {
+                return null;
+            }
+
+            object value = registryKey.GetValue(valueName);
+            registryKey.Close();
+            return value?.ToString();
+        }
+    }
+}

--- a/Interfaces/IDeviceEnumerator.cs
+++ b/Interfaces/IDeviceEnumerator.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace Elatec.NET.Interfaces
+{
+    /// <summary>
+    /// Abstraction for enumerating available reader devices on a platform.
+    /// </summary>
+    public interface IDeviceEnumerator
+    {
+        /// <summary>
+        /// Discover available TWN4 reader devices.
+        /// </summary>
+        /// <returns>List of connected reader devices.</returns>
+        List<TWN4ReaderDevice> GetAvailableReaders();
+    }
+}

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -33,3 +33,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.4.1.0")]
 [assembly: AssemblyFileVersion("0.4.1.0")]
+[assembly: InternalsVisibleTo("Elatec.NET.Tests")]


### PR DESCRIPTION
## Summary
- introduce a device enumeration interface with platform-specific implementations and placeholders for Linux/macOS
- refactor device discovery to a registry-backed Windows enumerator with argument validation and driver warnings
- add unit tests covering registry parsing helpers and expose internals for testing

## Testing
- not run (dotnet CLI unavailable in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69407399b4e083319e1d2ce1a0180d49)