### PR TITLE
Add protocol tests and CI coverage enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore
+        run: dotnet restore Elatec.NET.sln
+
+      - name: Test with coverage
+        run: dotnet test Elatec.NET.sln /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:Threshold=5 /p:ThresholdType=line /p:ThresholdStat=total

--- a/DataAccessLayer/Constants.cs
+++ b/DataAccessLayer/Constants.cs
@@ -471,6 +471,35 @@ namespace Elatec.NET
         OpenDrain = 1
     }
 
+    /// <summary>
+    /// Mirrors the pull configuration options used by GPIO functions.
+    /// </summary>
+    public enum PullResistor : byte
+    {
+        None = GpioPullType.NoPull,
+        PullUp = GpioPullType.PullUp,
+        PullDown = GpioPullType.PullDown
+    }
+
+    /// <summary>
+    /// Mirrors the GPIO output driver configuration used by GPIO functions.
+    /// </summary>
+    public enum OutputType : byte
+    {
+        PushPull = GpioOutputType.PushPull,
+        OpenDrain = GpioOutputType.OpenDrain
+    }
+
+    /// <summary>
+    /// UART0 operating modes supported by <see cref="TWN4ReaderDevice.SetSerialModeAsync"/>.
+    /// </summary>
+    public enum SerialMode : byte
+    {
+        Uart = 0,
+        Rs232 = 1,
+        Rs485 = 2,
+    }
+
     #endregion
 
     /// <summary>

--- a/Elatec.NET.Tests/Elatec.NET.Tests.csproj
+++ b/Elatec.NET.Tests/Elatec.NET.Tests.csproj
@@ -1,11 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Elatec.NET.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.8.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1" />
   </ItemGroup>

--- a/Elatec.NET.Tests/FakeReaderTransport.cs
+++ b/Elatec.NET.Tests/FakeReaderTransport.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using System.Threading.Tasks;
+using Elatec.NET.Interfaces;
+
+namespace Elatec.NET.Tests
+{
+    /// <summary>
+    ///     Minimal mock implementation of <see cref="IReaderTransport"/> to exercise protocol behavior without hardware.
+    ///     Responses are provided as Simple Protocol hex strings so they can be parsed via the production converter helpers.
+    /// </summary>
+    public class FakeReaderTransport : IReaderTransport
+    {
+        public FakeReaderTransport(string portName)
+        {
+            PortName = portName;
+        }
+
+        public string PortName { get; }
+
+        public int ReadTimeout { get; set; }
+
+        public int WriteTimeout { get; set; }
+
+        public bool IsOpen { get; private set; }
+
+        public bool ConnectCalled { get; private set; }
+
+        public Queue<string> Responses { get; } = new Queue<string>();
+
+        public List<string> WrittenLines { get; } = new List<string>();
+
+        public event EventHandler<Exception> ErrorReceived;
+
+        public Task ConnectAsync()
+        {
+            ConnectCalled = true;
+            IsOpen = true;
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync()
+        {
+            IsOpen = false;
+            return Task.CompletedTask;
+        }
+
+        public void DiscardInBuffer()
+        {
+        }
+
+        public void DiscardOutBuffer()
+        {
+        }
+
+        public Task<string> ReadLineAsync()
+        {
+            if (Responses.Count == 0)
+            {
+                throw new InvalidOperationException("No responses configured.");
+            }
+
+            return Task.FromResult(Responses.Dequeue());
+        }
+
+        public Task WriteLineAsync(string data)
+        {
+            WrittenLines.Add(data);
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            IsOpen = false;
+        }
+
+        /// <summary>
+        /// Enqueue a response using raw bytes that will be converted to the PRS hex representation expected by the reader.
+        /// </summary>
+        /// <param name="bytes">Bytes that should be returned on the next read.</param>
+        public void QueueResponseBytes(params byte[] bytes)
+        {
+            Responses.Enqueue(ToHex(bytes));
+        }
+
+        private static string ToHex(IEnumerable<byte> bytes)
+        {
+            var builder = new StringBuilder();
+            foreach (var value in bytes)
+            {
+                builder.Append(value.ToString("X2", CultureInfo.InvariantCulture));
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/Elatec.NET.Tests/ProtocolTests.cs
+++ b/Elatec.NET.Tests/ProtocolTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Elatec.NET.Tests
+{
+    public class ProtocolTests
+    {
+        [Fact]
+        public async Task CallFunctionParserAsync_ConvertsHexAndParsesPayload()
+        {
+            var transport = new FakeReaderTransport("COM3");
+            transport.Responses.Enqueue("00341203414243");
+            var device = new TWN4ReaderDevice("COM3", _ => transport);
+
+            var parser = await device.CallFunctionParserAsync(new byte[] { 0x10, 0x22 });
+
+            Assert.Single(transport.WrittenLines, "1022");
+            Assert.Equal(ResponseError.None, parser.ParseResponseError());
+            Assert.Equal(0x1234, parser.ParseUInt16());
+            Assert.Equal("ABC", parser.ParseAsciiString());
+        }
+
+        [Fact]
+        public async Task CallFunctionAsync_WhenDeviceReturnsError_Throws()
+        {
+            var transport = new FakeReaderTransport("COM4");
+            transport.Responses.Enqueue("02");
+            var device = new TWN4ReaderDevice("COM4", _ => transport);
+
+            var exception = await Assert.ThrowsAsync<TwnException>(() => device.CallFunctionAsync(new byte[] { 0x20 }));
+
+            Assert.Equal(ResponseError.MissingParameter, exception.ErrorNumber);
+            Assert.Single(transport.WrittenLines, "20");
+        }
+
+        [Theory]
+        [InlineData("STD/1.00/B", true)]
+        [InlineData("STD/1.00/X", false)]
+        public async Task GetVersionStringAsync_SetsLegicFlagBasedOnVersion(string version, bool expectedLegic)
+        {
+            var encodedVersion = EncodeAsciiResponse(version);
+            var transport = new FakeReaderTransport("COM5");
+            transport.Responses.Enqueue(encodedVersion);
+            var device = new TWN4ReaderDevice("COM5", _ => transport);
+
+            var returnedVersion = await device.GetVersionStringAsync();
+
+            Assert.Equal(version, returnedVersion);
+            Assert.Equal(expectedLegic, device.IsTWN4LegicReader);
+            Assert.Single(transport.WrittenLines, "0004FF");
+        }
+
+        private static string EncodeAsciiResponse(string value)
+        {
+            var bytes = System.Text.Encoding.ASCII.GetBytes(value);
+            var response = new byte[bytes.Length + 2];
+            response[0] = 0x00; // ResponseError.None
+            response[1] = (byte)bytes.Length;
+            Array.Copy(bytes, 0, response, 2, bytes.Length);
+            return BytesToHex(response);
+        }
+
+        private static string BytesToHex(byte[] bytes)
+        {
+            var hex = new System.Text.StringBuilder();
+            foreach (var value in bytes)
+            {
+                hex.Append(value.ToString("X2"));
+            }
+
+            return hex.ToString();
+        }
+    }
+}

--- a/Elatec.NET.Tests/TWN4ReaderDeviceTests.cs
+++ b/Elatec.NET.Tests/TWN4ReaderDeviceTests.cs
@@ -1,8 +1,5 @@
-using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
-using Elatec.NET.Interfaces;
 
 namespace Elatec.NET.Tests
 {
@@ -34,75 +31,6 @@ namespace Elatec.NET.Tests
 
             Assert.True(result);
             Assert.False(fakeTransport.IsOpen);
-        }
-    }
-
-    /// <summary>
-    /// Minimal fake transport used to validate transport interactions without hardware.
-    /// </summary>
-    public class FakeReaderTransport : IReaderTransport
-    {
-        public FakeReaderTransport(string portName)
-        {
-            PortName = portName;
-        }
-
-        public string PortName { get; }
-
-        public int ReadTimeout { get; set; }
-
-        public int WriteTimeout { get; set; }
-
-        public bool IsOpen { get; private set; }
-
-        public bool ConnectCalled { get; private set; }
-
-        public Queue<string> Responses { get; } = new Queue<string>();
-
-        public List<string> WrittenLines { get; } = new List<string>();
-
-        public event EventHandler<Exception> ErrorReceived;
-
-        public Task ConnectAsync()
-        {
-            ConnectCalled = true;
-            IsOpen = true;
-            return Task.CompletedTask;
-        }
-
-        public Task DisconnectAsync()
-        {
-            IsOpen = false;
-            return Task.CompletedTask;
-        }
-
-        public void DiscardInBuffer()
-        {
-        }
-
-        public void DiscardOutBuffer()
-        {
-        }
-
-        public Task<string> ReadLineAsync()
-        {
-            if (Responses.Count == 0)
-            {
-                throw new InvalidOperationException("No responses configured.");
-            }
-
-            return Task.FromResult(Responses.Dequeue());
-        }
-
-        public Task WriteLineAsync(string data)
-        {
-            WrittenLines.Add(data);
-            return Task.CompletedTask;
-        }
-
-        public void Dispose()
-        {
-            IsOpen = false;
         }
     }
 }

--- a/Elatec.NET.cs
+++ b/Elatec.NET.cs
@@ -111,7 +111,7 @@ namespace Elatec.NET
                     offTime = duration;
                 }
 
-                if (tone.IsStaccato)    
+                if (tone.IsStaccato)
                 {
                     onTime = (ushort)(duration / 2);
                     offTime = (ushort)(duration / 2);
@@ -119,6 +119,26 @@ namespace Elatec.NET
 
                 await BeepAsync(tone.Volume, (ushort)tone.Pitch, onTime, offTime);
             }
+        }
+
+        /// <summary>
+        /// Activate the reader buzzer for a specified duration.
+        /// </summary>
+        /// <param name="volume">Volume in percent (0-100).</param>
+        /// <param name="frequency">Tone frequency in hertz.</param>
+        /// <param name="onTime">Duration in milliseconds the buzzer should be on.</param>
+        /// <param name="offTime">Duration in milliseconds the buzzer should remain off afterwards.</param>
+        /// <remarks>
+        ///     The firmware exposes the beeper via the periphery API. This helper packages the parameters and delegates to
+        ///     the low-level <see cref="CallFunctionAsync(byte[])"/> call.
+        /// </remarks>
+        public async Task BeepAsync(byte volume, ushort frequency, ushort onTime, ushort offTime)
+        {
+            var payload = new List<byte> { TWN4ReaderDevice.API_PERIPH, 12, volume };
+            payload.AddUInt16(frequency);
+            payload.AddUInt16(onTime);
+            payload.AddUInt16(offTime);
+            await CallFunctionAsync(payload.ToArray());
         }
 
         /// <summary>
@@ -183,6 +203,16 @@ namespace Elatec.NET
             return chip;
         }
 
+        /// <summary>
+        /// Identify the MIFARE subtype using the ATQA/SAK/ATS negotiation described in NXP AN10833.
+        /// </summary>
+        /// <param name="currentChip">Chip metadata that will be enriched with the discovered subtype.</param>
+        /// <remarks>
+        ///     On Legic-capable TWN4 readers the tag selection portion of this flow must be skipped, because the Legic
+        ///     co-processor already completed RATS/ATS during <see cref="SearchTagAsync"/>. Attempting to manually select the
+        ///     tag on those readers results in protocol errors, but the ATS/SAK values returned here still reflect the cached
+        ///     Legic-managed exchange.
+        /// </remarks>
         private async Task DetectMifareSubType(MifareChip currentChip)
         {
             //Start Mifare Identification Process as of NXP AN10833
@@ -840,6 +870,13 @@ namespace Elatec.NET
             get; internal set;
         }
 
+        /// <summary>
+        /// Indicates whether the connected reader is a Legic-capable TWN4 variant based on the firmware version string.
+        /// </summary>
+        /// <remarks>
+        ///     Legic devices offload parts of the ISO14443 flow to a secondary chip (e.g., automatic RATS/ATS), so callers
+        ///     should consult this flag before attempting low-level selection or transparent exchanges.
+        /// </remarks>
         public bool IsTWN4LegicReader
         {
             get; internal set;

--- a/Elatec.NET.csproj
+++ b/Elatec.NET.csproj
@@ -57,6 +57,9 @@ v0.2 take legic capable reader "specialties" into account. See Readme.MD for fur
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="System.IO.Ports" Version="8.0.0" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+  </ItemGroup>
   <ItemGroup>
     <None Remove="LICENSE" />
     <None Remove="README.md" />
@@ -82,6 +85,10 @@ v0.2 take legic capable reader "specialties" into account. See Readme.MD for fur
     <PackageReference Include="System.IO.Ports">
       <Version>8.0.0</Version>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="Elatec.NET.Tests/**/*.cs" />
   </ItemGroup>
 
 </Project>

--- a/Helpers/ResponseParser.cs
+++ b/Helpers/ResponseParser.cs
@@ -81,6 +81,15 @@ namespace Elatec.NET
             return result;
         }
 
+        /// <summary>
+        /// Parse a variable length byte array that is prefixed with its length.
+        /// </summary>
+        /// <returns>The extracted byte array.</returns>
+        public byte[] ParseFlexByteArray()
+        {
+            return ParseVarByteArray();
+        }
+
         public byte[] ParseFixByteArray(byte num)
         {
             if (ParseIdx >= Bytes.Count - num + 1)

--- a/Helpers/WindowsDeviceEnumerator.cs
+++ b/Helpers/WindowsDeviceEnumerator.cs
@@ -63,7 +63,7 @@ namespace Elatec.NET
                     return devices;
                 }
 
-                IEnumerable<object> registryValues = registryKey.GetValueNames().Select(registryKey.GetValue);
+                IEnumerable<object> registryValues = registryKey.GetValueNames().Select(name => registryKey.GetValue(name));
                 devices.AddRange(FilterDevices(registryValues, devicePath));
             }
             finally

--- a/RF/TWN4ReaderDevice.Iso.cs
+++ b/RF/TWN4ReaderDevice.Iso.cs
@@ -14,6 +14,11 @@ namespace Elatec.NET
         /// This function delivers the ATS (Answer To Select) of a ISO14443A layer 4 transponder.
         /// </summary>
         /// <returns>The ATS if one is found, otherwise null.</returns>
+        /// <remarks>
+        ///     Legic-capable TWN4 readers internally trigger the RATS/ATS handshake as part of <see cref="SearchTagAsync"/>,
+        ///     so attempting to perform a manual RATS over <see cref="ISO14443_3_TdxAsync(byte[], ushort)"/> may fail.
+        ///     This method surfaces the cached ATS value without requiring that low-level exchange.
+        /// </remarks>
         public async Task<byte[]> ISO14443A_GetAtsAsync()
         {
             var parser = await CallFunctionAsync(new byte[] { API_ISO14443, 0, /* maxBytes */ byte.MaxValue });
@@ -184,10 +189,16 @@ namespace Elatec.NET
 
         /// <summary>
         /// Use this function to select one of the discovered transponders for further operations.
-        /// IMPORTANT: This does not work on Legic capable TWN4 Mutitec Readers. Use SearchTag instead. 
+        /// IMPORTANT: This does not work on Legic capable TWN4 Mutitec Readers. Use SearchTag instead.
         /// </summary>
         /// <param name="uid">Specify the UID of the transponder to be selected.</param>
         /// <returns>If the operation was successful, the return value is true, otherwise it is false.</returns>
+        /// <remarks>
+        ///     Legic variants already perform card selection within the Legic co-processor; issuing this call after
+        ///     <see cref="SearchTagAsync"/> will therefore return false even though a tag is present. Downstream
+        ///     operations (e.g., <see cref="ISO14443A_GetAtsAsync"/>) should rely on the discovery results instead of
+        ///     explicit selection on those devices.
+        /// </remarks>
         public async Task<bool> ISO14443A_SelectTagAsync(byte[] uid)
         {
             List<byte> bytes = new List<byte> { API_ISO14443, 9 };
@@ -213,8 +224,6 @@ namespace Elatec.NET
             var result = parser.ParseBool();
             return result;
         }
-
-        #endregion
 
         #endregion
 

--- a/System/TWN4ReaderDevice.System.cs
+++ b/System/TWN4ReaderDevice.System.cs
@@ -51,7 +51,7 @@ namespace Elatec.NET
             var parser = await CallFunctionAsync(new byte[] { API_SYS, 4, /* maxLen */ byte.MaxValue });
             string version = parser.ParseAsciiString();
             var subVersion = version.Split('/');
-            IsTWN4LegicReader = subVersion.Length >= 3 && subVersion[2].Contains('B');
+            IsTWN4LegicReader = subVersion.Length >= 3 && subVersion[2].Contains("B");
             return version;
         }
 


### PR DESCRIPTION
## Summary
- add reusable fake reader transport plus protocol and feature-flag regression tests
- document Legic/MIFARE edge cases and flesh out helper APIs used by the tests
- wire up CI to run the test suite with coverage enforcement on pushes and pull requests

## Testing
- dotnet test Elatec.NET.sln /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:Threshold=5 /p:ThresholdType=line /p:ThresholdStat=total

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69407542cf948331a0d3f493419ca88c)