### PR TITLE
Unify TWN4ReaderDevice namespaces and add System API test

### DIFF
--- a/APIs/System/TWN4ReaderDevice.System.cs
+++ b/APIs/System/TWN4ReaderDevice.System.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Elatec.NET.Helpers.ByteArrayHelper.Extensions;
 
-namespace Elatec.NET.APIs.System
+namespace Elatec.NET
 {
     public partial class TWN4ReaderDevice
     {

--- a/Elatec.NET.Tests/TWN4ReaderDeviceTests.cs
+++ b/Elatec.NET.Tests/TWN4ReaderDeviceTests.cs
@@ -32,5 +32,22 @@ namespace Elatec.NET.Tests
             Assert.True(result);
             Assert.False(fakeTransport.IsOpen);
         }
+
+        [Fact]
+        public async Task GetVersionStringAsync_ParsesResponseAndSetsLegicFlag()
+        {
+            const string versionString = "FW/1.0/B1";
+            var fakeTransport = new FakeReaderTransport("COM3");
+            fakeTransport.QueueResponseBytes(0x00, (byte)versionString.Length,
+                0x46, 0x57, 0x2F, 0x31, 0x2E, 0x30, 0x2F, 0x42, 0x31);
+
+            var device = new TWN4ReaderDevice("COM3", _ => fakeTransport);
+
+            var result = await device.GetVersionStringAsync();
+
+            Assert.Equal("0004FF", Assert.Single(fakeTransport.WrittenLines));
+            Assert.Equal(versionString, result);
+            Assert.True(device.IsTWN4LegicReader);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- align the System API partial with the main TWN4ReaderDevice namespace so partial declarations compile together
- add a unit test that exercises GetVersionStringAsync to keep the System API discoverable on the reader type

## Testing
- dotnet test *(fails: project missing DESFire-related types referenced by Mifare Desfire API)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694083a05db48331b93c278f2104a397)