### PR TITLE
Fix transport factory initialization and namespace qualifiers

### DIFF
--- a/Elatec.NET.Tests/ProtocolTests.cs
+++ b/Elatec.NET.Tests/ProtocolTests.cs
@@ -53,7 +53,7 @@ namespace Elatec.NET.Tests
 
         private static string EncodeAsciiResponse(string value)
         {
-            var bytes = System.Text.Encoding.ASCII.GetBytes(value);
+            var bytes = global::System.Text.Encoding.ASCII.GetBytes(value);
             var response = new byte[bytes.Length + 2];
             response[0] = 0x00; // ResponseError.None
             response[1] = (byte)bytes.Length;
@@ -63,7 +63,7 @@ namespace Elatec.NET.Tests
 
         private static string BytesToHex(byte[] bytes)
         {
-            var hex = new System.Text.StringBuilder();
+            var hex = new global::System.Text.StringBuilder();
             foreach (var value in bytes)
             {
                 hex.Append(value.ToString("X2"));

--- a/Elatec.NET.cs
+++ b/Elatec.NET.cs
@@ -10,6 +10,7 @@ using Elatec.NET.Helpers.ByteArrayHelper.Extensions;
 using System.IO;
 using Elatec.NET.Cards;
 using Elatec.NET.Cards.Mifare;
+using Elatec.NET.System;
 
 /*
 * Elatec.NET is a C# library to easily Talk to Elatec's TWN4 Devices
@@ -68,7 +69,7 @@ namespace Elatec.NET
         public TWN4ReaderDevice(string portName, Func<string, IReaderTransport> transportFactory = null)
         {
             PortName = portName;
-            _transportFactory = transportFactory ?? (name => new SerialPortTransport(name));
+            _transportFactory = transportFactory ?? new Func<string, IReaderTransport>(name => new SerialPortTransport(name));
         }
 
         /// <summary>

--- a/Helpers/ByteArray.cs
+++ b/Helpers/ByteArray.cs
@@ -368,7 +368,7 @@ namespace Elatec.NET.Helpers.ByteArrayHelper
                 {
                     if (!(hex.Length > 2 || hex.Length <= 0))
                     {
-                        newByte = byte.Parse(hex, System.Globalization.NumberStyles.HexNumber);
+                        newByte = byte.Parse(hex, global::System.Globalization.NumberStyles.HexNumber);
                     }
                 }
                 catch


### PR DESCRIPTION
## Summary
- ensure TWN4ReaderDevice uses a typed default transport factory and imports the SerialPortTransport namespace
- qualify System namespace usages in ByteArray and tests to avoid conflicts with the project System namespace

## Testing
- dotnet test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69408cc128608331ae852f87adf8cfb6)