### PR TITLE
Add Simple Protocol binary framing helpers and length-prefixed parsing (APIDocRev28)

### DIFF
--- a/src/Internal/DataAccess/Constants.cs
+++ b/src/Internal/DataAccess/Constants.cs
@@ -363,6 +363,7 @@ namespace Elatec.NET
 
     /// <summary>
     /// A response to a TWN Simple Protocol command always starts with a byte, which reflects execution of the command on protocol level.
+    /// See APIDocRev28 section 38.5 (Simple Protocol).
     /// </summary>
     public enum ResponseError : byte
     {
@@ -372,6 +373,29 @@ namespace Elatec.NET
         UnusedParameters = 3,
         InvalidFunction = 4,
         ParserError = 5,
+    }
+
+    /// <summary>
+    /// Communication mode flags for Simple Protocol initialization.
+    /// See APIDocRev28 section 38.5.1 (SimpleProtoInit).
+    /// </summary>
+    [Flags]
+    public enum SimpleProtocolCommMode : ushort
+    {
+        /// <summary>
+        /// ASCII framing mode (default firmware setting).
+        /// </summary>
+        Ascii = 0x0000,
+
+        /// <summary>
+        /// Binary framing mode with a 2-byte length prefix.
+        /// </summary>
+        Binary = 0x0001,
+
+        /// <summary>
+        /// Enable CRC framing on Simple Protocol exchanges.
+        /// </summary>
+        CrcOn = 0x0002,
     }
 
     /// <summary>

--- a/src/Internal/Parsing/ResponseParser.cs
+++ b/src/Internal/Parsing/ResponseParser.cs
@@ -43,6 +43,23 @@ namespace Elatec.NET
             return (ushort)(num | (ushort)(Bytes[ParseIdx++] << 8));
         }
 
+        /// <summary>
+        /// Parse a length-prefixed byte array with a UInt16 length prefix (LSB first).
+        /// </summary>
+        /// <returns>The extracted byte array.</returns>
+        public byte[] ParseUInt16LengthPrefixedByteArray()
+        {
+            var length = ParseUInt16();
+            if (ParseIdx >= Bytes.Count - length + 1)
+            {
+                throw new ApplicationException("Response too short");
+            }
+            var result = new byte[length];
+            Bytes.CopyTo(ParseIdx, result, 0, length);
+            ParseIdx += length;
+            return result;
+        }
+
         public uint ParseUInt32()
         {
             uint num = 0u;

--- a/src/Internal/Protocol/SimpleProtocolFrame.cs
+++ b/src/Internal/Protocol/SimpleProtocolFrame.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Collections.Generic;
+
+namespace Elatec.NET
+{
+    /// <summary>
+    /// Parse results for Simple Protocol binary frames (length-prefixed, optional CRC).
+    /// See APIDocRev28 section 38.5 for Simple Protocol mode details.
+    /// </summary>
+    public enum SimpleProtocolFrameStatus
+    {
+        /// <summary>
+        /// Frame parsed successfully.
+        /// </summary>
+        Ok = 0,
+
+        /// <summary>
+        /// Not enough bytes have been received to parse the complete frame.
+        /// </summary>
+        IncompleteFrame = 1,
+
+        /// <summary>
+        /// The length prefix is inconsistent with the available buffer.
+        /// </summary>
+        InvalidLengthPrefix = 2,
+
+        /// <summary>
+        /// CRC validation failed for the received payload.
+        /// </summary>
+        InvalidChecksum = 3,
+    }
+
+    /// <summary>
+    /// Represents a parsed Simple Protocol binary frame payload.
+    /// </summary>
+    public readonly struct SimpleProtocolFrame
+    {
+        public SimpleProtocolFrame(byte[] payload)
+        {
+            Payload = payload ?? throw new ArgumentNullException(nameof(payload));
+        }
+
+        /// <summary>
+        /// Raw payload bytes (length prefix and CRC removed).
+        /// </summary>
+        public byte[] Payload { get; }
+    }
+
+    /// <summary>
+    /// Helpers for Simple Protocol binary framing (length prefix + optional CRC).
+    /// The CRC algorithm is based on the Simple Protocol framing described in DocRev25 (1.3.3) and
+    /// referenced by APIDocRev28 section 38.5 (Simple Protocol).
+    /// </summary>
+    public static class SimpleProtocolFrameCodec
+    {
+        private const int LengthPrefixSize = 2;
+        private const int CrcSize = 2;
+
+        /// <summary>
+        /// Build a length-prefixed Simple Protocol binary frame with optional CRC.
+        /// </summary>
+        /// <param name="payload">Payload bytes to send.</param>
+        /// <param name="includeCrc">When true, append the Simple Protocol CRC after the payload.</param>
+        /// <returns>Framed payload with length prefix and optional CRC.</returns>
+        public static byte[] BuildBinaryFrame(byte[] payload, bool includeCrc)
+        {
+            if (payload == null) throw new ArgumentNullException(nameof(payload));
+            if (payload.Length > ushort.MaxValue)
+                throw new ArgumentOutOfRangeException(nameof(payload), "Payload too large for Simple Protocol length prefix.");
+
+            var frame = new List<byte>(LengthPrefixSize + payload.Length + (includeCrc ? CrcSize : 0));
+            frame.AddUInt16((ushort)payload.Length);
+            frame.AddRange(payload);
+
+            if (includeCrc)
+            {
+                var crc = ComputeCrc(payload);
+                frame.AddUInt16(crc);
+            }
+
+            return frame.ToArray();
+        }
+
+        /// <summary>
+        /// Try to parse a single length-prefixed Simple Protocol binary frame from the buffer.
+        /// </summary>
+        /// <param name="buffer">Buffer containing at least one frame.</param>
+        /// <param name="hasCrc">Whether the frame is expected to include a CRC.</param>
+        /// <param name="frame">The parsed frame if successful.</param>
+        /// <param name="bytesConsumed">Number of bytes consumed from the buffer.</param>
+        /// <returns>Status describing the parsing outcome.</returns>
+        public static SimpleProtocolFrameStatus TryParseBinaryFrame(
+            IReadOnlyList<byte> buffer,
+            bool hasCrc,
+            out SimpleProtocolFrame frame,
+            out int bytesConsumed)
+        {
+            frame = default;
+            bytesConsumed = 0;
+            if (buffer == null) throw new ArgumentNullException(nameof(buffer));
+
+            if (buffer.Count < LengthPrefixSize)
+            {
+                return SimpleProtocolFrameStatus.IncompleteFrame;
+            }
+
+            var payloadLength = (ushort)(buffer[0] | (buffer[1] << 8));
+            var totalLength = LengthPrefixSize + payloadLength + (hasCrc ? CrcSize : 0);
+            if (totalLength < LengthPrefixSize)
+            {
+                return SimpleProtocolFrameStatus.InvalidLengthPrefix;
+            }
+
+            if (buffer.Count < totalLength)
+            {
+                return SimpleProtocolFrameStatus.IncompleteFrame;
+            }
+
+            var payload = new byte[payloadLength];
+            for (var i = 0; i < payloadLength; i++)
+            {
+                payload[i] = buffer[LengthPrefixSize + i];
+            }
+
+            if (hasCrc)
+            {
+                var crcOffset = LengthPrefixSize + payloadLength;
+                var receivedCrc = (ushort)(buffer[crcOffset] | (buffer[crcOffset + 1] << 8));
+                var expectedCrc = ComputeCrc(payload);
+                if (receivedCrc != expectedCrc)
+                {
+                    bytesConsumed = totalLength;
+                    return SimpleProtocolFrameStatus.InvalidChecksum;
+                }
+            }
+
+            frame = new SimpleProtocolFrame(payload);
+            bytesConsumed = totalLength;
+            return SimpleProtocolFrameStatus.Ok;
+        }
+
+        /// <summary>
+        /// Try to parse multiple frames from a buffer, useful when responses arrive back-to-back.
+        /// </summary>
+        /// <param name="buffer">Buffer containing one or more frames.</param>
+        /// <param name="hasCrc">Whether the frames are expected to include a CRC.</param>
+        /// <param name="frames">Parsed frames in order.</param>
+        /// <param name="bytesConsumed">Total number of bytes consumed from the buffer.</param>
+        /// <returns>Status describing the parsing outcome.</returns>
+        public static SimpleProtocolFrameStatus TryParseBinaryFrames(
+            IReadOnlyList<byte> buffer,
+            bool hasCrc,
+            out List<SimpleProtocolFrame> frames,
+            out int bytesConsumed)
+        {
+            if (buffer == null) throw new ArgumentNullException(nameof(buffer));
+
+            frames = new List<SimpleProtocolFrame>();
+            bytesConsumed = 0;
+
+            while (bytesConsumed < buffer.Count)
+            {
+                var slice = new BufferSlice(buffer, bytesConsumed);
+                var status = TryParseBinaryFrame(slice, hasCrc, out var frame, out var consumed);
+                if (status != SimpleProtocolFrameStatus.Ok)
+                {
+                    return status;
+                }
+
+                frames.Add(frame);
+                bytesConsumed += consumed;
+            }
+
+            return SimpleProtocolFrameStatus.Ok;
+        }
+
+        /// <summary>
+        /// Compute the CCITT CRC (reverse polynomial 0x8408) used by Simple Protocol.
+        /// </summary>
+        /// <param name="payload">Payload bytes to include in the CRC calculation.</param>
+        /// <returns>CRC value.</returns>
+        public static ushort ComputeCrc(byte[] payload)
+        {
+            if (payload == null) throw new ArgumentNullException(nameof(payload));
+
+            ushort crc = 0xFFFF;
+            foreach (var value in payload)
+            {
+                crc = UpdateCrc(crc, value);
+            }
+
+            return crc;
+        }
+
+        private static ushort UpdateCrc(ushort crc, byte value)
+        {
+            var data = (byte)(value ^ crc);
+            data ^= (byte)(data << 4);
+            return (ushort)(((data << 8) | (crc >> 8)) ^ (data >> 4) ^ (data << 3));
+        }
+
+        private readonly struct BufferSlice : IReadOnlyList<byte>
+        {
+            private readonly IReadOnlyList<byte> _buffer;
+            private readonly int _offset;
+
+            public BufferSlice(IReadOnlyList<byte> buffer, int offset)
+            {
+                _buffer = buffer;
+                _offset = offset;
+            }
+
+            public int Count => _buffer.Count - _offset;
+
+            public byte this[int index] => _buffer[_offset + index];
+
+            public IEnumerator<byte> GetEnumerator()
+            {
+                for (var i = 0; i < Count; i++)
+                {
+                    yield return _buffer[_offset + i];
+                }
+            }
+
+            global::System.Collections.IEnumerator global::System.Collections.IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
+    }
+}

--- a/tests/Elatec.NET.Tests/ProtocolTests.cs
+++ b/tests/Elatec.NET.Tests/ProtocolTests.cs
@@ -1,11 +1,63 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
+using Elatec.NET;
 
 namespace Elatec.NET.Tests
 {
     public class ProtocolTests
     {
+        [Fact]
+        public void BuildBinaryFrame_IncludesLengthPrefixAndCrc()
+        {
+            var payload = new byte[] { 0x01, 0x02, 0x03 };
+            var crc = SimpleProtocolFrameCodec.ComputeCrc(payload);
+
+            var frame = SimpleProtocolFrameCodec.BuildBinaryFrame(payload, includeCrc: true);
+
+            Assert.Equal(new byte[]
+            {
+                0x03, 0x00, // length prefix (LSB first)
+                0x01, 0x02, 0x03,
+                (byte)(crc & 0xFF),
+                (byte)((crc >> 8) & 0xFF)
+            }, frame);
+        }
+
+        [Fact]
+        public void TryParseBinaryFrames_ParsesMultiPartResponses()
+        {
+            var payloadA = new byte[] { 0xAA, 0xBB };
+            var payloadB = new byte[] { 0xCC };
+            var frameA = SimpleProtocolFrameCodec.BuildBinaryFrame(payloadA, includeCrc: false);
+            var frameB = SimpleProtocolFrameCodec.BuildBinaryFrame(payloadB, includeCrc: false);
+            var buffer = new byte[frameA.Length + frameB.Length];
+            Array.Copy(frameA, 0, buffer, 0, frameA.Length);
+            Array.Copy(frameB, 0, buffer, frameA.Length, frameB.Length);
+
+            var status = SimpleProtocolFrameCodec.TryParseBinaryFrames(buffer, hasCrc: false, out var frames, out var consumed);
+
+            Assert.Equal(SimpleProtocolFrameStatus.Ok, status);
+            Assert.Equal(buffer.Length, consumed);
+            Assert.Equal(2, frames.Count);
+            Assert.Equal(payloadA, frames[0].Payload);
+            Assert.Equal(payloadB, frames[1].Payload);
+        }
+
+        [Fact]
+        public void ParseUInt16LengthPrefixedByteArray_ReadsPayload()
+        {
+            var payload = new byte[] { 0x10, 0x11, 0x12 };
+            var bytes = new List<byte>();
+            bytes.AddUInt16((ushort)payload.Length);
+            bytes.AddRange(payload);
+
+            var parser = new ResponseParser(bytes);
+
+            Assert.Equal(payload, parser.ParseUInt16LengthPrefixedByteArray());
+        }
+
         [Fact]
         public async Task CallFunctionParserAsync_ConvertsHexAndParsesPayload()
         {


### PR DESCRIPTION
### Motivation

- Add support for Simple Protocol binary-mode framing and multi-part responses as described in APIDocRev28 section 38.5. 
- Provide helpers for length-prefixed payloads and CRC handling to match the TWN4 Simple Protocol binary framing rules.
- Surface communication-mode flags used by `SimpleProtoInit` so callers can select ASCII/binary and CRC options.
- Ensure higher-level parsers can consume multi-frame responses and new payload shapes used by newer firmware revisions.

### Description

- Introduces `SimpleProtocolFrameCodec` and supporting types in `src/Internal/Protocol/SimpleProtocolFrame.cs` with `BuildBinaryFrame`, `TryParseBinaryFrame`, `TryParseBinaryFrames`, and `ComputeCrc` (CCITT reverse polynomial 0x8408) for length-prefixed frames with optional CRC.
- Adds `SimpleProtocolCommMode` enum to `src/Internal/DataAccess/Constants.cs` with flags for ASCII/Binary and CRC modes and updates the Simple Protocol comment to reference APIDocRev28.
- Adds `ResponseParser.ParseUInt16LengthPrefixedByteArray()` in `src/Internal/Parsing/ResponseParser.cs` to parse UInt16-prefixed payloads (LSB first).
- Adds unit tests in `tests/Elatec.NET.Tests/ProtocolTests.cs` covering frame construction (`BuildBinaryFrame_IncludesLengthPrefixAndCrc`), multi-frame parsing (`TryParseBinaryFrames_ParsesMultiPartResponses`) and the new parser helper (`ParseUInt16LengthPrefixedByteArray_ReadsPayload`).

### Testing

- Ran the test suite with `dotnet test tests/Elatec.NET.Tests/Elatec.NET.Tests.csproj` and all tests passed (`Passed: 17, Failed: 0`).
- New unit tests exercise CRC framing, multi-frame parsing and UInt16-prefixed parsing and succeeded.
- Project builds successfully for the test target frameworks during the test run.
- No failing automated tests were observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947c2cfc1848331ab599c3787c65695)