### PR TITLE
Add serial-port adapter, guard open/close with lock and disposal, and add tests

### DIFF
--- a/src/Drivers/Transport/SerialPortAdapter.cs
+++ b/src/Drivers/Transport/SerialPortAdapter.cs
@@ -1,0 +1,152 @@
+using System;
+using System.IO.Ports;
+
+namespace Elatec.NET.System
+{
+    /// <summary>
+    /// Provides an abstraction layer around <see cref="SerialPort"/> for testing.
+    /// </summary>
+    internal interface ISerialPortAdapter : IDisposable
+    {
+        string PortName { get; set; }
+
+        int BaudRate { get; set; }
+
+        int DataBits { get; set; }
+
+        StopBits StopBits { get; set; }
+
+        Parity Parity { get; set; }
+
+        string NewLine { get; set; }
+
+        int ReadTimeout { get; set; }
+
+        int WriteTimeout { get; set; }
+
+        bool IsOpen { get; }
+
+        event SerialErrorReceivedEventHandler ErrorReceived;
+
+        void Open();
+
+        void Close();
+
+        void DiscardInBuffer();
+
+        void DiscardOutBuffer();
+
+        string ReadLine();
+
+        void WriteLine(string data);
+    }
+
+    internal sealed class SerialPortAdapter : ISerialPortAdapter
+    {
+        private readonly SerialPort _serialPort;
+
+        public SerialPortAdapter(string portName)
+        {
+            _serialPort = new SerialPort
+            {
+                PortName = portName,
+                BaudRate = 9600,
+                DataBits = 8,
+                StopBits = StopBits.One,
+                Parity = Parity.None,
+                NewLine = "\r"
+            };
+        }
+
+        public string PortName
+        {
+            get => _serialPort.PortName;
+            set => _serialPort.PortName = value;
+        }
+
+        public int BaudRate
+        {
+            get => _serialPort.BaudRate;
+            set => _serialPort.BaudRate = value;
+        }
+
+        public int DataBits
+        {
+            get => _serialPort.DataBits;
+            set => _serialPort.DataBits = value;
+        }
+
+        public StopBits StopBits
+        {
+            get => _serialPort.StopBits;
+            set => _serialPort.StopBits = value;
+        }
+
+        public Parity Parity
+        {
+            get => _serialPort.Parity;
+            set => _serialPort.Parity = value;
+        }
+
+        public string NewLine
+        {
+            get => _serialPort.NewLine;
+            set => _serialPort.NewLine = value;
+        }
+
+        public int ReadTimeout
+        {
+            get => _serialPort.ReadTimeout;
+            set => _serialPort.ReadTimeout = value;
+        }
+
+        public int WriteTimeout
+        {
+            get => _serialPort.WriteTimeout;
+            set => _serialPort.WriteTimeout = value;
+        }
+
+        public bool IsOpen => _serialPort.IsOpen;
+
+        public event SerialErrorReceivedEventHandler ErrorReceived
+        {
+            add => _serialPort.ErrorReceived += value;
+            remove => _serialPort.ErrorReceived -= value;
+        }
+
+        public void Open()
+        {
+            _serialPort.Open();
+        }
+
+        public void Close()
+        {
+            _serialPort.Close();
+        }
+
+        public void DiscardInBuffer()
+        {
+            _serialPort.DiscardInBuffer();
+        }
+
+        public void DiscardOutBuffer()
+        {
+            _serialPort.DiscardOutBuffer();
+        }
+
+        public string ReadLine()
+        {
+            return _serialPort.ReadLine();
+        }
+
+        public void WriteLine(string data)
+        {
+            _serialPort.WriteLine(data);
+        }
+
+        public void Dispose()
+        {
+            _serialPort.Dispose();
+        }
+    }
+}

--- a/src/Drivers/Transport/SerialPortTransport.cs
+++ b/src/Drivers/Transport/SerialPortTransport.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.IO.Ports;
 using System.Threading.Tasks;
+using System.Threading;
 using Elatec.NET.Interfaces;
 
 namespace Elatec.NET.System
@@ -11,29 +12,27 @@ namespace Elatec.NET.System
     /// </summary>
     public class SerialPortTransport : IReaderTransport
     {
-        private readonly SerialPort _serialPort;
+        private readonly ISerialPortAdapter _serialPort;
+        private readonly SemaphoreSlim _connectionLock = new SemaphoreSlim(1, 1);
+        private bool _disposed;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SerialPortTransport"/> class for the given port.
         /// </summary>
         /// <param name="portName">Name of the serial port used to reach the reader.</param>
         public SerialPortTransport(string portName)
+            : this(CreateConfiguredPort(portName))
         {
-            if (string.IsNullOrWhiteSpace(portName))
+        }
+
+        internal SerialPortTransport(ISerialPortAdapter serialPort)
+        {
+            if (serialPort == null)
             {
-                throw new ArgumentException("Port name must be provided.", nameof(portName));
+                throw new ArgumentNullException(nameof(serialPort));
             }
 
-            _serialPort = new SerialPort
-            {
-                PortName = portName,
-                BaudRate = 9600,
-                DataBits = 8,
-                StopBits = StopBits.One,
-                Parity = Parity.None,
-                NewLine = "\r"
-            };
-
+            _serialPort = serialPort;
             _serialPort.ErrorReceived += OnErrorReceived;
         }
 
@@ -63,19 +62,30 @@ namespace Elatec.NET.System
         /// <inheritdoc />
         public async Task ConnectAsync()
         {
-            await Task.Run(() =>
+            ThrowIfDisposed();
+
+            await _connectionLock.WaitAsync().ConfigureAwait(false);
+            try
             {
+                ThrowIfDisposed();
                 if (!_serialPort.IsOpen)
                 {
                     _serialPort.Open();
                 }
-            }).ConfigureAwait(false);
+            }
+            finally
+            {
+                _connectionLock.Release();
+            }
         }
 
         /// <inheritdoc />
         public async Task DisconnectAsync()
         {
-            await Task.Run(() =>
+            ThrowIfDisposed();
+
+            await _connectionLock.WaitAsync().ConfigureAwait(false);
+            try
             {
                 if (_serialPort.IsOpen)
                 {
@@ -83,49 +93,97 @@ namespace Elatec.NET.System
                     _serialPort.DiscardOutBuffer();
                     _serialPort.Close();
                 }
-            }).ConfigureAwait(false);
+            }
+            finally
+            {
+                _connectionLock.Release();
+            }
         }
 
         /// <inheritdoc />
         public void DiscardInBuffer()
         {
+            ThrowIfDisposed();
             _serialPort.DiscardInBuffer();
         }
 
         /// <inheritdoc />
         public void DiscardOutBuffer()
         {
+            ThrowIfDisposed();
             _serialPort.DiscardOutBuffer();
         }
 
         /// <inheritdoc />
         public async Task<string> ReadLineAsync()
         {
+            ThrowIfDisposed();
             return await Task.Run(() => _serialPort.ReadLine()).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
         public async Task WriteLineAsync(string data)
         {
+            ThrowIfDisposed();
             await Task.Run(() => _serialPort.WriteLine(data)).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
         public void Dispose()
         {
-            _serialPort.ErrorReceived -= OnErrorReceived;
-
-            if (_serialPort.IsOpen)
+            if (_disposed)
             {
-                _serialPort.Close();
+                return;
             }
 
-            _serialPort.Dispose();
+            _connectionLock.Wait();
+            try
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                _serialPort.ErrorReceived -= OnErrorReceived;
+
+                if (_serialPort.IsOpen)
+                {
+                    _serialPort.DiscardInBuffer();
+                    _serialPort.DiscardOutBuffer();
+                    _serialPort.Close();
+                }
+
+                _serialPort.Dispose();
+            }
+            finally
+            {
+                _connectionLock.Release();
+                _connectionLock.Dispose();
+            }
         }
 
         private void OnErrorReceived(object sender, SerialErrorReceivedEventArgs e)
         {
             ErrorReceived?.Invoke(this, new IOException($"Serial port error: {e.EventType}"));
+        }
+
+        private static ISerialPortAdapter CreateConfiguredPort(string portName)
+        {
+            if (string.IsNullOrWhiteSpace(portName))
+            {
+                throw new ArgumentException("Port name must be provided.", nameof(portName));
+            }
+
+            return new SerialPortAdapter(portName);
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(SerialPortTransport));
+            }
         }
     }
 }

--- a/tests/Elatec.NET.Tests/SerialPortTransportTests.cs
+++ b/tests/Elatec.NET.Tests/SerialPortTransportTests.cs
@@ -1,0 +1,134 @@
+using System;
+using System.IO.Ports;
+using System.Threading.Tasks;
+using Elatec.NET.System;
+using Xunit;
+
+namespace Elatec.NET.Tests
+{
+    public class SerialPortTransportTests
+    {
+        [Fact]
+        public async Task ConnectAsync_OpensPortOnce()
+        {
+            var adapter = new FakeSerialPortAdapter();
+            using var transport = new SerialPortTransport(adapter);
+
+            await transport.ConnectAsync();
+            await transport.ConnectAsync();
+
+            Assert.True(adapter.IsOpen);
+            Assert.Equal(1, adapter.OpenCallCount);
+        }
+
+        [Fact]
+        public async Task DisconnectAsync_ClosesAndDiscardsBuffers()
+        {
+            var adapter = new FakeSerialPortAdapter();
+            using var transport = new SerialPortTransport(adapter);
+
+            await transport.ConnectAsync();
+            await transport.DisconnectAsync();
+
+            Assert.False(adapter.IsOpen);
+            Assert.Equal(1, adapter.DiscardInBufferCallCount);
+            Assert.Equal(1, adapter.DiscardOutBufferCallCount);
+            Assert.Equal(1, adapter.CloseCallCount);
+        }
+
+        [Fact]
+        public async Task Dispose_ClosesOpenPort()
+        {
+            var adapter = new FakeSerialPortAdapter();
+            var transport = new SerialPortTransport(adapter);
+
+            await transport.ConnectAsync();
+            transport.Dispose();
+
+            Assert.False(adapter.IsOpen);
+            Assert.Equal(1, adapter.DiscardInBufferCallCount);
+            Assert.Equal(1, adapter.DiscardOutBufferCallCount);
+            Assert.Equal(1, adapter.CloseCallCount);
+        }
+
+        [Fact]
+        public async Task ConnectAsync_ThrowsWhenDisposed()
+        {
+            var adapter = new FakeSerialPortAdapter();
+            var transport = new SerialPortTransport(adapter);
+
+            transport.Dispose();
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => transport.ConnectAsync());
+        }
+
+        private sealed class FakeSerialPortAdapter : ISerialPortAdapter
+        {
+            public string PortName { get; set; } = "COM1";
+
+            public int BaudRate { get; set; }
+
+            public int DataBits { get; set; }
+
+            public StopBits StopBits { get; set; }
+
+            public Parity Parity { get; set; }
+
+            public string NewLine { get; set; } = "\r";
+
+            public int ReadTimeout { get; set; }
+
+            public int WriteTimeout { get; set; }
+
+            public bool IsOpen { get; private set; }
+
+            public int OpenCallCount { get; private set; }
+
+            public int CloseCallCount { get; private set; }
+
+            public int DiscardInBufferCallCount { get; private set; }
+
+            public int DiscardOutBufferCallCount { get; private set; }
+
+#pragma warning disable CS0067
+            public event SerialErrorReceivedEventHandler ErrorReceived;
+#pragma warning restore CS0067
+
+            public void Open()
+            {
+                OpenCallCount++;
+                IsOpen = true;
+            }
+
+            public void Close()
+            {
+                CloseCallCount++;
+                IsOpen = false;
+            }
+
+            public void DiscardInBuffer()
+            {
+                DiscardInBufferCallCount++;
+            }
+
+            public void DiscardOutBuffer()
+            {
+                DiscardOutBufferCallCount++;
+            }
+
+            public string ReadLine()
+            {
+                return "OK";
+            }
+
+            public void WriteLine(string data)
+            {
+            }
+
+            public void Dispose()
+            {
+                IsOpen = false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Make serial transport testable by removing direct dependency on `System.IO.Ports.SerialPort` and enable unit testing of open/close behavior.
- Harden serial port handling to avoid races and improper use after disposal when opening/closing concurrently.
- Ensure buffers are discarded and event handlers are cleaned up on disconnect/dispose to avoid resource leaks.

### Description
- Introduce `ISerialPortAdapter` and `SerialPortAdapter` in `src/Drivers/Transport/SerialPortAdapter.cs` to wrap `SerialPort` for testability.
- Refactor `SerialPortTransport` to depend on `ISerialPortAdapter`, add a `SemaphoreSlim` `_connectionLock`, `_disposed` checks, `ThrowIfDisposed()` and `CreateConfiguredPort()` factory method, and ensure event unsubscription and buffer discard on dispose.
- Replace ad-hoc `Task.Run` wrappers around open/close with proper async locking and disposal guards in `ConnectAsync`/`DisconnectAsync` and add safe `Dispose` logic.
- Add unit tests `tests/Elatec.NET.Tests/SerialPortTransportTests.cs` with a `FakeSerialPortAdapter` to validate open-once behavior, disconnect buffer discard, dispose closing, and thrown exceptions when using after dispose.

### Testing
- Ran `dotnet test tests/Elatec.NET.Tests/Elatec.NET.Tests.csproj` to execute the test suite.
- All tests passed: `Passed!  - Failed:     0, Passed:    21, Skipped:     0, Total:    21`.
- Test run produced some non-fatal compiler warnings about unused events, but no test failures occurred.
- Unit tests cover `ConnectAsync`, `DisconnectAsync`, `Dispose`, and behavior when calling `ConnectAsync` after disposal.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695113425630833180acf188c6967fab)