### PR TITLE
Fix DESFire access rights packing order

### DIFF
--- a/src/Api/Cards/Mifare/MifareKey.cs
+++ b/src/Api/Cards/Mifare/MifareKey.cs
@@ -313,6 +313,35 @@ namespace Elatec.NET.Cards.Mifare
         private byte readWriteKeyNo;
         private byte changeKeyNo;
 
+        /// <summary>
+        /// Pack access rights in DESFire datasheet nibble order:
+        /// Read (bits 15-12), Write (11-8), Read&Write (7-4), Change (3-0).
+        /// </summary>
+        /// <returns>Access rights word in datasheet order.</returns>
+        public ushort ToAccessRightsWord()
+        {
+            return (ushort)(((readKeyNo & 0x0F) << 12)
+                | ((writeKeyNo & 0x0F) << 8)
+                | ((readWriteKeyNo & 0x0F) << 4)
+                | (changeKeyNo & 0x0F));
+        }
+
+        /// <summary>
+        /// Unpack a DESFire access rights word using datasheet nibble order.
+        /// </summary>
+        /// <param name="accessRights">Access rights word in datasheet order.</param>
+        /// <returns><see cref="DESFireFileAccessRights"/> instance.</returns>
+        public static DESFireFileAccessRights FromAccessRightsWord(ushort accessRights)
+        {
+            return new DESFireFileAccessRights
+            {
+                ReadKeyNo = (byte)((accessRights >> 12) & 0x0F),
+                WriteKeyNo = (byte)((accessRights >> 8) & 0x0F),
+                ReadWriteKeyNo = (byte)((accessRights >> 4) & 0x0F),
+                ChangeKeyNo = (byte)(accessRights & 0x0F)
+            };
+        }
+
         public byte ReadKeyNo
         {
             get => readKeyNo; set => readKeyNo = value;

--- a/src/Api/Readers/TWN4ReaderDevice/Protocols/TWN4ReaderDevice.MifareDesfire.cs
+++ b/src/Api/Readers/TWN4ReaderDevice/Protocols/TWN4ReaderDevice.MifareDesfire.cs
@@ -266,11 +266,7 @@ namespace Elatec.NET
                 fileSettings.ComSett = parser.ParseByte();
 
                 var ar = parser.ParseUInt16();
-
-                fileSettings.accessRights.ReadKeyNo = (byte)(ar & 0x000F);
-                fileSettings.accessRights.WriteKeyNo = (byte)((ar & 0x00F0) >> 4);
-                fileSettings.accessRights.ReadWriteKeyNo = (byte)((ar & 0x0F00) >> 8);
-                fileSettings.accessRights.ChangeKeyNo = (byte)((ar & 0xF000) >> 12);
+                fileSettings.accessRights = DESFireFileAccessRights.FromAccessRightsWord(ar);
 
                 switch (fileSettings.FileType)
                 {
@@ -593,12 +589,7 @@ namespace Elatec.NET
         {
             List<byte> bytes = new List<byte> { API_MIFAREDESFIRE, MIFARE_DESFIRE_CREATE_STDDATAFILE, CRYPTO_ENV, fileNo, (byte)fileType, (byte)mode };
 
-            UInt16 fileAccessRights = 0;
-
-            fileAccessRights |= accessRights.ReadKeyNo;
-            fileAccessRights |= (byte)(accessRights.WriteKeyNo << 4);
-            fileAccessRights |= (byte)(accessRights.ReadWriteKeyNo << 8);
-            fileAccessRights |= (byte)(accessRights.ChangeKeyNo << 12);
+            UInt16 fileAccessRights = accessRights.ToAccessRightsWord();
 
             bytes.AddUInt16(fileAccessRights);
             bytes.AddUInt32(fileSize);
@@ -638,12 +629,7 @@ namespace Elatec.NET
         {
             List<byte> bytes = new List<byte> { API_MIFAREDESFIRE, MIFARE_DESFIRE_CREATE_VALUEFILE, CRYPTO_ENV, fileNo, (byte)fileType, (byte)mode };
 
-            UInt16 fileAccessRights = 0;
-
-            fileAccessRights |= accessRights.ReadKeyNo;
-            fileAccessRights |= (UInt16)(accessRights.WriteKeyNo << 4);
-            fileAccessRights |= (UInt16)(accessRights.ReadWriteKeyNo << 8);
-            fileAccessRights |= (UInt16)(accessRights.ChangeKeyNo << 12);
+            UInt16 fileAccessRights = accessRights.ToAccessRightsWord();
 
             bytes.AddUInt16(fileAccessRights);
             bytes.AddUInt32(lowerLimit);
@@ -851,17 +837,8 @@ namespace Elatec.NET
         {
             List<byte> bytes = new List<byte> { API_MIFAREDESFIRE, MIFARE_DESFIRE_CHANGEFILESETTINGS, CRYPTO_ENV, fileNo, (byte)newCommSet };
 
-            UInt16 oldAr = 0;
-            oldAr |= oldAccessRights.ReadKeyNo;
-            oldAr |= (UInt16)(oldAccessRights.WriteKeyNo << 4);
-            oldAr |= (UInt16)(oldAccessRights.ReadWriteKeyNo << 8);
-            oldAr |= (UInt16)(oldAccessRights.ChangeKeyNo << 12);
-
-            UInt16 newAr = 0;
-            newAr |= newAccessRights.ReadKeyNo;
-            newAr |= (UInt16)(newAccessRights.WriteKeyNo << 4);
-            newAr |= (UInt16)(newAccessRights.ReadWriteKeyNo << 8);
-            newAr |= (UInt16)(newAccessRights.ChangeKeyNo << 12);
+            UInt16 oldAr = oldAccessRights.ToAccessRightsWord();
+            UInt16 newAr = newAccessRights.ToAccessRightsWord();
 
             bytes.AddUInt16(oldAr);
             bytes.AddUInt16(newAr);
@@ -971,12 +948,7 @@ namespace Elatec.NET
         {
             List<byte> bytes = new List<byte> { API_MIFAREDESFIRE, MIFARE_DESFIRE_CREATERECORDFILE, CRYPTO_ENV, fileNo, (byte)fileType, (byte)mode };
 
-            UInt16 fileAccessRights = 0;
-
-            fileAccessRights |= accessRights.ReadKeyNo;
-            fileAccessRights |= (UInt16)(accessRights.WriteKeyNo << 4);
-            fileAccessRights |= (UInt16)(accessRights.ReadWriteKeyNo << 8);
-            fileAccessRights |= (UInt16)(accessRights.ChangeKeyNo << 12);
+            UInt16 fileAccessRights = accessRights.ToAccessRightsWord();
 
             bytes.AddUInt16(fileAccessRights);
             bytes.AddUInt32(recordSize);

--- a/tests/Elatec.NET.Tests/AccessRightsTests.cs
+++ b/tests/Elatec.NET.Tests/AccessRightsTests.cs
@@ -1,0 +1,33 @@
+using Xunit;
+using Elatec.NET.Cards.Mifare;
+
+namespace Elatec.NET.Tests
+{
+    public class AccessRightsTests
+    {
+        [Fact]
+        public void ToAccessRightsWord_PacksInDatasheetOrder()
+        {
+            var accessRights = new DESFireFileAccessRights
+            {
+                ReadKeyNo = 0x1,
+                WriteKeyNo = 0x2,
+                ReadWriteKeyNo = 0x3,
+                ChangeKeyNo = 0x4
+            };
+
+            Assert.Equal((ushort)0x1234, accessRights.ToAccessRightsWord());
+        }
+
+        [Fact]
+        public void FromAccessRightsWord_UnpacksInDatasheetOrder()
+        {
+            var accessRights = DESFireFileAccessRights.FromAccessRightsWord(0xABCD);
+
+            Assert.Equal(0xA, accessRights.ReadKeyNo);
+            Assert.Equal(0xB, accessRights.WriteKeyNo);
+            Assert.Equal(0xC, accessRights.ReadWriteKeyNo);
+            Assert.Equal(0xD, accessRights.ChangeKeyNo);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- The DESFire access-rights packing used by the library did not follow the datasheet nibble order and produced incorrect permission words on cards.
- The datasheet requires nibble order: Read (bits 15–12), Write (11–8), Read&Write (7–4), Change (3–0).
- The change corrects the packing/unpacking to match the spec and prevents producing reversed access-rights words.
- This is a breaking change for consumers that previously compensated for the reversed order.

### Description

- Added `ToAccessRightsWord()` and `FromAccessRightsWord(ushort)` on `DESFireFileAccessRights` to pack/unpack using the datasheet nibble order. 
- Replaced ad-hoc manual bit packing/unpacking in `TWN4ReaderDevice.MifareDesfire.cs` with the new helper methods (used for create/change/unpack of file access rights).
- Added unit tests `tests/Elatec.NET.Tests/AccessRightsTests.cs` to assert correct pack/unpack behavior.
- Kept public property names (`ReadKeyNo`, `WriteKeyNo`, `ReadWriteKeyNo`, `ChangeKeyNo`) unchanged for minimal surface-area impact, but behavior of packing is now spec-compliant.

### Testing

- Ran `dotnet test tests/Elatec.NET.Tests/Elatec.NET.Tests.csproj` and the test run completed successfully. 
- All tests passed: `Passed!  - Failed: 0, Passed: 23, Skipped: 0, Total: 23`.
- Project builds during the test run with no test failures. 
- New tests cover `ToAccessRightsWord` and `FromAccessRightsWord` packing/unpacking behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695274dae3688331a23bcd6be6563bd7)