### PR TITLE
Serialize transport access for async calls

### DIFF
--- a/src/Api/Readers/TWN4ReaderDevice/TWN4ReaderDevice.Core.cs
+++ b/src/Api/Readers/TWN4ReaderDevice/TWN4ReaderDevice.Core.cs
@@ -42,6 +42,8 @@ namespace Elatec.NET
 
         private static readonly object syncRoot = new object();
         private static List<TWN4ReaderDevice> instance;
+        // Serialize access to the underlying transport to prevent interleaved async commands.
+        private readonly SemaphoreSlim _transportLock = new SemaphoreSlim(1, 1);
         private readonly Func<string, IReaderTransport> _transportFactory;
         private IReaderTransport _transport;
 
@@ -811,6 +813,7 @@ namespace Elatec.NET
         /// <returns></returns>
         private async Task<byte[]> DoTXRXAsync(byte[] CMD)
         {
+            await _transportLock.WaitAsync().ConfigureAwait(false);
             try
             {
                 EnsureTransport();
@@ -835,6 +838,10 @@ namespace Elatec.NET
             catch
             {
                 throw new ReaderException("Call was not successfull, error " + Enum.GetName(typeof(ReaderError), ReaderError.NotOpen), null);
+            }
+            finally
+            {
+                _transportLock.Release();
             }
 
         }// End of DoTXRXAsync

--- a/tests/Elatec.NET.Tests/ConcurrentReaderTransport.cs
+++ b/tests/Elatec.NET.Tests/ConcurrentReaderTransport.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Elatec.NET.Interfaces;
+
+namespace Elatec.NET.Tests
+{
+    /// <summary>
+    /// Transport stub that detects overlapping Write/Read cycles to ensure calls are serialized.
+    /// </summary>
+    public class ConcurrentReaderTransport : IReaderTransport
+    {
+        private int _inFlight;
+
+        public ConcurrentReaderTransport(string portName)
+        {
+            PortName = portName;
+        }
+
+        public string PortName { get; }
+
+        public int ReadTimeout { get; set; }
+
+        public int WriteTimeout { get; set; }
+
+        public bool IsOpen { get; private set; }
+
+        public bool OverlapDetected { get; private set; }
+
+        public Queue<string> Responses { get; } = new Queue<string>();
+
+        public List<string> WrittenLines { get; } = new List<string>();
+
+        public TaskCompletionSource<bool> FirstWriteSeen { get; } = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource<bool> AllowRead { get; } = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public event EventHandler<Exception> ErrorReceived;
+
+        public Task ConnectAsync()
+        {
+            IsOpen = true;
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync()
+        {
+            IsOpen = false;
+            return Task.CompletedTask;
+        }
+
+        public void DiscardInBuffer()
+        {
+        }
+
+        public void DiscardOutBuffer()
+        {
+        }
+
+        public async Task<string> ReadLineAsync()
+        {
+            await AllowRead.Task.ConfigureAwait(false);
+            Interlocked.Exchange(ref _inFlight, 0);
+
+            if (Responses.Count == 0)
+            {
+                throw new InvalidOperationException("No responses configured.");
+            }
+
+            return Responses.Dequeue();
+        }
+
+        public Task WriteLineAsync(string data)
+        {
+            if (Interlocked.CompareExchange(ref _inFlight, 1, 0) == 1)
+            {
+                OverlapDetected = true;
+            }
+
+            WrittenLines.Add(data);
+            FirstWriteSeen.TrySetResult(true);
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            IsOpen = false;
+        }
+    }
+}

--- a/tests/Elatec.NET.Tests/TWN4ReaderDeviceTests.cs
+++ b/tests/Elatec.NET.Tests/TWN4ReaderDeviceTests.cs
@@ -102,5 +102,24 @@ namespace Elatec.NET.Tests
             Assert.Equal(0x01, result);
             Assert.Single(transport.WrittenLines, "00070500000001000000");
         }
+
+        [Fact]
+        public async Task CallFunctionRawAsync_SerializesConcurrentCalls()
+        {
+            var transport = new ConcurrentReaderTransport("COM8");
+            transport.Responses.Enqueue("00");
+            transport.Responses.Enqueue("00");
+            var device = new TWN4ReaderDevice("COM8", _ => transport);
+
+            var firstTask = device.CallFunctionRawAsync(new byte[] { 0xAA });
+            await transport.FirstWriteSeen.Task;
+            var secondTask = device.CallFunctionRawAsync(new byte[] { 0xBB });
+
+            transport.AllowRead.TrySetResult(true);
+            await Task.WhenAll(firstTask, secondTask);
+
+            Assert.False(transport.OverlapDetected);
+            Assert.Equal(2, transport.WrittenLines.Count);
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Concurrent async calls could interleave writes/reads on the underlying COM transport and provoke device-level `AccessDenied` errors, so transport access needs serialization inside the library.

### Description
- Added an async lock field `SemaphoreSlim _transportLock` to `TWN4ReaderDevice` to serialize access to the transport. 
- Wrapped the transport TX/RX path in `DoTXRXAsync` with `await _transportLock.WaitAsync()` and a `finally` that calls `_transportLock.Release()` to ensure calls do not overlap. 
- Added a test helper `ConcurrentReaderTransport` that detects overlapping write/read cycles. 
- Added a unit test `CallFunctionRawAsync_SerializesConcurrentCalls` to verify concurrent `CallFunctionRawAsync` calls are serialized and do not overlap.

### Testing
- Ran `dotnet test tests/Elatec.NET.Tests/Elatec.NET.Tests.csproj`, which executed the test suite and passed: 24 passed, 0 failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69739fccc11083318cfaed03160b534f)